### PR TITLE
Updated docs to reflect the new Approov 2.6 usage for the `approov secret` command

### DIFF
--- a/docker/todo-prod/.env.example
+++ b/docker/todo-prod/.env.example
@@ -11,7 +11,7 @@ BASE_URL_PUBLIC_HOST=phoenix-absinthe-graphql.demo.approov.io
 
 # APPROOV INTERNAL DEPLOYMENT ONLY: Use the Approov Base64 URL encoded secret
 # assigned for this production example. Ask the engineer team for iit.
-# OTHERS: Get the secret with `approov secret /path/to/administration.token -get base64url`
+# OTHERS: Get the secret with `approov secret -get base64url`
 APPROOV_BASE64URL_SECRET=___MUST_BE_BASE64_URL_ENCODED___
 
 # Generate one with:

--- a/docs/APPROOV_TOKEN_BINDING_QUICKSTART.md
+++ b/docs/APPROOV_TOKEN_BINDING_QUICKSTART.md
@@ -69,10 +69,10 @@ Approov tokens are signed with a symmetric secret. To verify tokens, we need to 
 Retrieve the Approov secret with:
 
 ```text
-approov secret /path/to/approov/administration.tok -get base64url
+approov secret -get base64url
 ```
 
-> **NOTE:** The `approov secret` command requires an administration management token to execute successfully. Developer management tokens don't have sufficient privileges to get the secret.
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 #### Set the Approov Secret
 

--- a/docs/APPROOV_TOKEN_QUICKSTART.md
+++ b/docs/APPROOV_TOKEN_QUICKSTART.md
@@ -66,10 +66,10 @@ Approov tokens are signed with a symmetric secret. To verify tokens, we need to 
 Retrieve the Approov secret with:
 
 ```text
-approov secret /path/to/approov/administration.tok -get base64url
+approov secret -get base64url
 ```
 
-> **NOTE:** The `approov secret` command requires an administration management token to execute successfully. Developer management tokens don't have sufficient privileges to get the secret.
+> **NOTE:** The `approov secret` command requires an [administration role](https://approov.io/docs/latest/approov-usage-documentation/#account-access-roles) to execute successfully.
 
 #### Set the Approov Secret
 

--- a/src/approov-protected-server/token-binding-check/todo/.env.example
+++ b/src/approov-protected-server/token-binding-check/todo/.env.example
@@ -31,5 +31,5 @@ LIVE_VIEW_DASHBOARD_PASSWORD=___NO_LESS_THEN_12_LENGTH_PASSWORD_HERE___
 
 # APPROOV INTERNAL DEPLOYMENT ONLY: Use the Approov Base64 URL encoded secret
 # assigned for this production example. Ask the engineer team for it.
-# OTHERS: Get the secret with `approov secret /path/to/administration.token -get base64url`
+# OTHERS: Get the secret with `approov secret -get base64url`
 APPROOV_BASE64URL_SECRET=___MUST_BE_BASE64_URL_ENCODED___

--- a/src/approov-protected-server/token-check/todo/.env.example
+++ b/src/approov-protected-server/token-check/todo/.env.example
@@ -31,5 +31,5 @@ LIVE_VIEW_DASHBOARD_PASSWORD=___NO_LESS_THEN_12_LENGTH_PASSWORD_HERE___
 
 # APPROOV INTERNAL DEPLOYMENT ONLY: Use the Approov Base64 URL encoded secret
 # assigned for this production example. Ask the engineer team for it.
-# OTHERS: Get the secret with `approov secret /path/to/administration.token -get base64url`
+# OTHERS: Get the secret with `approov secret -get base64url`
 APPROOV_BASE64URL_SECRET=___MUST_BE_BASE64_URL_ENCODED___

--- a/src/unprotected-server/todo/.env.example
+++ b/src/unprotected-server/todo/.env.example
@@ -31,5 +31,5 @@ LIVE_VIEW_DASHBOARD_PASSWORD=___NO_LESS_THEN_12_LENGTH_PASSWORD_HERE___
 
 # APPROOV INTERNAL DEPLOYMENT ONLY: Use the Approov Base64 URL encoded secret
 # assigned for this production example. Ask the engineer team for it.
-# OTHERS: Get the secret with `approov secret /path/to/administration.token -get base64url`
+# OTHERS: Get the secret with `approov secret -get base64url`
 APPROOV_BASE64URL_SECRET=___MUST_BE_BASE64_URL_ENCODED___


### PR DESCRIPTION
Signed-off-by: Exadra37 <exadra37@gmail.com>