### PR TITLE
Fixed GraphQL subscriptions not working due to the missing x-approov-token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ defmodule ApproovToken do
   defp _get_approov_token(%{"x-approov-token" => approov_token}), do: {:ok, approov_token}
   defp _get_approov_token(%{"X-Approov-Token" => approov_token}), do: {:ok, approov_token}
 
+  defp _get_approov_token(%{x_headers: x_headers}) when is_list(x_headers) do
+    case Utils.filter_list_of_tuples(x_headers, "x-approov-token") do
+      nil ->
+        {:ok, Utils.filter_list_of_tuples(x_headers, "X-Approov-Token")}
+
+      approov_token ->
+        {:ok, approov_token}
+    end
+  end
+
   # For when is not possible to retrieve the Approov token.
   defp _get_approov_token(_params) do
     {:error, :missing_approov_token}

--- a/docs/APPROOV_TOKEN_BINDING_QUICKSTART.md
+++ b/docs/APPROOV_TOKEN_BINDING_QUICKSTART.md
@@ -321,6 +321,16 @@ defmodule ApproovToken do
   defp _get_approov_token(%{"x-approov-token" => approov_token}), do: {:ok, approov_token}
   defp _get_approov_token(%{"X-Approov-Token" => approov_token}), do: {:ok, approov_token}
 
+  defp _get_approov_token(%{x_headers: x_headers}) when is_list(x_headers) do
+    case Utils.filter_list_of_tuples(x_headers, "x-approov-token") do
+      nil ->
+        {:ok, Utils.filter_list_of_tuples(x_headers, "X-Approov-Token")}
+
+      approov_token ->
+        {:ok, approov_token}
+    end
+  end
+
   # Catch failure to fetch the Approov token from the WebSocket upgrade request
   # or from the Phoenix Channel event.
   defp _get_approov_token(_params) do

--- a/docs/APPROOV_TOKEN_QUICKSTART.md
+++ b/docs/APPROOV_TOKEN_QUICKSTART.md
@@ -258,6 +258,16 @@ defmodule ApproovToken do
   defp _get_approov_token(%{"x-approov-token" => approov_token}), do: {:ok, approov_token}
   defp _get_approov_token(%{"X-Approov-Token" => approov_token}), do: {:ok, approov_token}
 
+  defp _get_approov_token(%{x_headers: x_headers}) when is_list(x_headers) do
+    case Utils.filter_list_of_tuples(x_headers, "x-approov-token") do
+      nil ->
+        {:ok, Utils.filter_list_of_tuples(x_headers, "X-Approov-Token")}
+
+      approov_token ->
+        {:ok, approov_token}
+    end
+  end
+
   # Catch failure to fetch the Approov token from the WebSocket upgrade request
   # or from the Phoenix Channel event.
   defp _get_approov_token(_params) do

--- a/src/approov-protected-server/token-binding-check/todo/lib/approov_token.ex
+++ b/src/approov-protected-server/token-binding-check/todo/lib/approov_token.ex
@@ -8,6 +8,8 @@ defmodule ApproovToken do
 
   # Verifies the token from an HTTP request or from a Websockets connection/event
   def verify_token(params) do
+    Logger.info(%{verify_approov_token_params: params})
+
     with {:ok, approov_token} <- _get_approov_token(params),
          {:ok, approov_token_claims} <- _decode_and_verify(approov_token) do
 
@@ -37,9 +39,11 @@ defmodule ApproovToken do
     end
   end
 
-  defp _get_approov_token(%{x_headers: x_headers})
-    when is_list(x_headers) and length(x_headers) > 0
-  do
+  # For a Phoenix Channel event, where the token is provided in the event payload.
+  defp _get_approov_token(%{"x-approov-token" => approov_token}), do: {:ok, approov_token}
+  defp _get_approov_token(%{"X-Approov-Token" => approov_token}), do: {:ok, approov_token}
+
+  defp _get_approov_token(%{x_headers: x_headers}) when is_list(x_headers) do
     case Utils.filter_list_of_tuples(x_headers, "x-approov-token") do
       nil ->
         {:ok, Utils.filter_list_of_tuples(x_headers, "X-Approov-Token")}
@@ -48,11 +52,6 @@ defmodule ApproovToken do
         {:ok, approov_token}
     end
   end
-
-  # Fetch for a Phoenix Channel event, where the token is provided in the event
-  # payload.
-  defp _get_approov_token(%{"x-approov-token" => approov_token}), do: {:ok, approov_token}
-  defp _get_approov_token(%{"X-Approov-Token" => approov_token}), do: {:ok, approov_token}
 
   # Catch failure to fetch the Approov token from the WebSocket upgrade request
   # or from the Phoenix Channel event.

--- a/src/approov-protected-server/token-binding-check/todo/lib/todo/online_user.ex
+++ b/src/approov-protected-server/token-binding-check/todo/lib/todo/online_user.ex
@@ -8,6 +8,7 @@ defmodule Todos.OnlineUser do
     {
       :ok,
       Todos.Repo.all!(@table)
+      |> Enum.map(fn user -> Map.put(user, :last_seen, Calendar.strftime(user.last_seen, "%c")) end)
     }
   end
 

--- a/src/approov-protected-server/token-check/todo/lib/todo/online_user.ex
+++ b/src/approov-protected-server/token-check/todo/lib/todo/online_user.ex
@@ -8,6 +8,7 @@ defmodule Todos.OnlineUser do
     {
       :ok,
       Todos.Repo.all!(@table)
+      |> Enum.map(fn user -> Map.put(user, :last_seen, Calendar.strftime(user.last_seen, "%c")) end)
     }
   end
 

--- a/src/unprotected-server/todo/lib/todo/online_user.ex
+++ b/src/unprotected-server/todo/lib/todo/online_user.ex
@@ -8,6 +8,7 @@ defmodule Todos.OnlineUser do
     {
       :ok,
       Todos.Repo.all!(@table)
+      |> Enum.map(fn user -> Map.put(user, :last_seen, Calendar.strftime(user.last_seen, "%c")) end)
     }
   end
 


### PR DESCRIPTION
The missing function to match the `x-headers` must have been removed accidentally at some point in the past when I was porting changes between Elixir quickstarts.

Signed-off-by: Exadra37 <exadra37@gmail.com>